### PR TITLE
fix(Row): Forbidden focus should only be applied to edge items 

### DIFF
--- a/android/src/main/java/com/rs/leanbacknative/models/Card.java
+++ b/android/src/main/java/com/rs/leanbacknative/models/Card.java
@@ -13,6 +13,8 @@ public class Card implements Serializable {
 
     @Expose private int index;
 
+    @Expose private Boolean isLast;
+
     @Expose private int viewId;
 
     @Expose private String title;
@@ -89,6 +91,14 @@ public class Card implements Serializable {
 
     public void setIndex(int index) {
         this.index = index;
+    }
+
+    public Boolean getIsLast() {
+        return isLast;
+    }
+
+    public void setIsLast(Boolean isLast) {
+        this.isLast = isLast;
     }
 
     public String getBackdropUrl() {

--- a/android/src/main/java/com/rs/leanbacknative/models/Card.java
+++ b/android/src/main/java/com/rs/leanbacknative/models/Card.java
@@ -93,7 +93,7 @@ public class Card implements Serializable {
         this.index = index;
     }
 
-    public Boolean getIsLast() {
+    public Boolean isLast() {
         return isLast;
     }
 

--- a/android/src/main/java/com/rs/leanbacknative/presenters/AbstractCardPresenter.java
+++ b/android/src/main/java/com/rs/leanbacknative/presenters/AbstractCardPresenter.java
@@ -2,7 +2,6 @@ package com.rs.leanbacknative.presenters;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;

--- a/android/src/main/java/com/rs/leanbacknative/presenters/AbstractCardPresenter.java
+++ b/android/src/main/java/com/rs/leanbacknative/presenters/AbstractCardPresenter.java
@@ -94,15 +94,7 @@ public abstract class AbstractCardPresenter<T extends BaseCardView> extends Pres
             cardView.setId(card.getViewId());
 
         if (mForbiddenFocusDirections != null) {
-            List<String> forbiddenFocus = toStringArrayList(mForbiddenFocusDirections);
-            if(card.getIndex() != 0){
-                forbiddenFocus = filterStringArrayList(forbiddenFocus, Constants.FOCUS_DIRECTION_LEFT);
-            }
-            if(!card.getIsLast()){
-                forbiddenFocus = filterStringArrayList(forbiddenFocus, Constants.FOCUS_DIRECTION_RIGHT);
-            }
-
-            Utils.setForbiddenFocusDirections(forbiddenFocus, cardView);
+            Utils.setForbiddenFocusDirections(mForbiddenFocusDirections, card, cardView);
         }
 
         if (nextFocusUpId != -1)
@@ -129,29 +121,5 @@ public abstract class AbstractCardPresenter<T extends BaseCardView> extends Pres
                 .apply(requestOptions)
                 .error(mDefaultCardImage)
                 .into(imageView);
-    }
-
-    public ArrayList<String> toStringArrayList(ReadableArray array) {
-        ArrayList<String> arrayList = new ArrayList<>();
-
-        for (int i = 0; i < array.size(); i++) {
-            arrayList.add(array.getString(i));
-        }
-        return arrayList;
-    }
-
-    public List<String> filterStringArrayList(List<String> list, String value){
-        // create an empty list
-        List<String> filteredList = new ArrayList<>();
-
-        // iterate through the list
-        for (String entry: list)
-        {
-            // filter values that match entered value to filter out
-            if (!entry.matches(value)) {
-                filteredList.add(entry);
-            }
-        }
-        return filteredList;
     }
 }

--- a/android/src/main/java/com/rs/leanbacknative/presenters/AbstractCardPresenter.java
+++ b/android/src/main/java/com/rs/leanbacknative/presenters/AbstractCardPresenter.java
@@ -2,6 +2,7 @@ package com.rs.leanbacknative.presenters;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -22,6 +23,10 @@ import com.rs.leanbacknative.R;
 import com.rs.leanbacknative.models.Card;
 import com.rs.leanbacknative.utils.Constants;
 import com.rs.leanbacknative.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public abstract class AbstractCardPresenter<T extends BaseCardView> extends Presenter {
     protected Drawable mDefaultCardImage;
@@ -89,8 +94,17 @@ public abstract class AbstractCardPresenter<T extends BaseCardView> extends Pres
         if (cardView.getId() == -1)
             cardView.setId(card.getViewId());
 
-        if (mForbiddenFocusDirections != null)
-            Utils.setForbiddenFocusDirections(mForbiddenFocusDirections, cardView);
+        if (mForbiddenFocusDirections != null) {
+            List<String> forbiddenFocus = toStringArrayList(mForbiddenFocusDirections);
+            if(card.getIndex() != 0){
+                forbiddenFocus = filterStringArrayList(forbiddenFocus, Constants.FOCUS_DIRECTION_LEFT);
+            }
+            if(!card.getIsLast()){
+                forbiddenFocus = filterStringArrayList(forbiddenFocus, Constants.FOCUS_DIRECTION_RIGHT);
+            }
+
+            Utils.setForbiddenFocusDirections(forbiddenFocus, cardView);
+        }
 
         if (nextFocusUpId != -1)
             cardView.setNextFocusUpId(nextFocusUpId);
@@ -116,5 +130,29 @@ public abstract class AbstractCardPresenter<T extends BaseCardView> extends Pres
                 .apply(requestOptions)
                 .error(mDefaultCardImage)
                 .into(imageView);
+    }
+
+    public ArrayList<String> toStringArrayList(ReadableArray array) {
+        ArrayList<String> arrayList = new ArrayList<>();
+
+        for (int i = 0; i < array.size(); i++) {
+            arrayList.add(array.getString(i));
+        }
+        return arrayList;
+    }
+
+    public List<String> filterStringArrayList(List<String> list, String value){
+        // create an empty list
+        List<String> filteredList = new ArrayList<>();
+
+        // iterate through the list
+        for (String entry: list)
+        {
+            // filter values that match entered value to filter out
+            if (!entry.matches(value)) {
+                filteredList.add(entry);
+            }
+        }
+        return filteredList;
     }
 }

--- a/android/src/main/java/com/rs/leanbacknative/presenters/AbstractCardPresenter.java
+++ b/android/src/main/java/com/rs/leanbacknative/presenters/AbstractCardPresenter.java
@@ -33,10 +33,10 @@ public abstract class AbstractCardPresenter<T extends BaseCardView> extends Pres
     protected Integer mCardWidth = Constants.DEFAULT_CARD_WIDTH;
     protected Integer mCardHeight = Constants.DEFAULT_CARD_HEIGHT;
     protected ReadableArray mForbiddenFocusDirections;
-    protected int nextFocusUpId = -1;
-    protected int nextFocusDownId = -1;
-    protected int nextFocusLeftId = -1;
-    protected int nextFocusRightId = -1;
+    protected int nextFocusUpId = View.NO_ID;
+    protected int nextFocusDownId = View.NO_ID;
+    protected int nextFocusLeftId = View.NO_ID;
+    protected int nextFocusRightId = View.NO_ID;
     protected int mBorderRadius;
     protected boolean mHasImageOnly;
     protected String mImageTransformationMode;
@@ -71,7 +71,10 @@ public abstract class AbstractCardPresenter<T extends BaseCardView> extends Pres
     public abstract void onBindViewHolder(Card card, T cardView);
 
     public void onUnbindViewHolder(T cardView) {
-
+        cardView.setNextFocusLeftId(View.NO_ID);
+        cardView.setNextFocusRightId(View.NO_ID);
+        cardView.setNextFocusUpId(View.NO_ID);
+        cardView.setNextFocusDownId(View.NO_ID);
     }
 
     void initializeAttributes(ReadableMap attributes) {
@@ -90,23 +93,23 @@ public abstract class AbstractCardPresenter<T extends BaseCardView> extends Pres
     }
 
     void setFocusRules(View cardView, Card card) {
-        if (cardView.getId() == -1)
+        if (cardView.getId() == View.NO_ID)
             cardView.setId(card.getViewId());
 
         if (mForbiddenFocusDirections != null) {
             Utils.setForbiddenFocusDirections(mForbiddenFocusDirections, card, cardView);
         }
 
-        if (nextFocusUpId != -1)
+        if (nextFocusUpId != View.NO_ID)
             cardView.setNextFocusUpId(nextFocusUpId);
 
-        if (nextFocusDownId != -1)
+        if (nextFocusDownId != View.NO_ID)
             cardView.setNextFocusDownId(nextFocusDownId);
 
-        if (nextFocusLeftId != -1)
+        if (nextFocusLeftId != View.NO_ID && card.getIndex() == 0)
             cardView.setNextFocusLeftId(nextFocusLeftId);
 
-        if (nextFocusRightId != -1)
+        if (nextFocusRightId != View.NO_ID && card.isLast())
             cardView.setNextFocusRightId(nextFocusRightId);
     }
 

--- a/android/src/main/java/com/rs/leanbacknative/presenters/DefaultCardPresenter.java
+++ b/android/src/main/java/com/rs/leanbacknative/presenters/DefaultCardPresenter.java
@@ -71,5 +71,9 @@ public class DefaultCardPresenter extends AbstractCardPresenter<DefaultImageCard
     public void onUnbindViewHolder(DefaultImageCardView cardView) {
         cardView.setBadgeImage(null);
         cardView.setMainImage(null);
+        cardView.setNextFocusLeftId(View.NO_ID);
+        cardView.setNextFocusRightId(View.NO_ID);
+        cardView.setNextFocusUpId(View.NO_ID);
+        cardView.setNextFocusDownId(View.NO_ID);
     }
 }

--- a/android/src/main/java/com/rs/leanbacknative/presenters/GridCardPresenter.java
+++ b/android/src/main/java/com/rs/leanbacknative/presenters/GridCardPresenter.java
@@ -80,5 +80,9 @@ public class GridCardPresenter extends AbstractCardPresenter<DefaultImageCardVie
     public void onUnbindViewHolder(DefaultImageCardView cardView) {
         cardView.setBadgeImage(null);
         cardView.setMainImage(null);
+        cardView.setNextFocusLeftId(View.NO_ID);
+        cardView.setNextFocusRightId(View.NO_ID);
+        cardView.setNextFocusUpId(View.NO_ID);
+        cardView.setNextFocusDownId(View.NO_ID);
     }
 }

--- a/android/src/main/java/com/rs/leanbacknative/utils/Constants.java
+++ b/android/src/main/java/com/rs/leanbacknative/utils/Constants.java
@@ -4,7 +4,7 @@ public class Constants {
     public static final String FOCUS_DIRECTION_UP = "up";
     public static final String FOCUS_DIRECTION_DOWN = "down";
     public static final String FOCUS_DIRECTION_LEFT = "left";
-    public static final String FOCUS_DIRECTION_RIGHT = "left";
+    public static final String FOCUS_DIRECTION_RIGHT = "right";
     public static final String FOCUSED_CARD_ALIGNMENT_LEFT = "left";
     public static final String FOCUSED_CARD_ALIGNMENT_CENTER = "center";
     public static final String FOCUSED_CARD_ALIGNMENT_LEANBACK = "leanback";

--- a/android/src/main/java/com/rs/leanbacknative/utils/DataManager.java
+++ b/android/src/main/java/com/rs/leanbacknative/utils/DataManager.java
@@ -35,7 +35,7 @@ public class DataManager {
 
             Card card = new Card();
             card.setIndex(i);
-            card.setIsLast(i == data.size()-1);
+            card.setIsLast(i == data.size());
             card.setViewId(viewId);
             card.setId(validateString(dataRowItem, "id"));
             card.setTitle(validateString(dataRowItem, "title"));

--- a/android/src/main/java/com/rs/leanbacknative/utils/DataManager.java
+++ b/android/src/main/java/com/rs/leanbacknative/utils/DataManager.java
@@ -62,7 +62,6 @@ public class DataManager {
 
         if (viewIds.size() == 0) {
             viewIds = ids;
-            Log.d("ADDING_TO_ARRAY", viewIds.toString());
         }
 
         return rows;
@@ -129,4 +128,3 @@ public class DataManager {
         return res;
     }
 }
-

--- a/android/src/main/java/com/rs/leanbacknative/utils/DataManager.java
+++ b/android/src/main/java/com/rs/leanbacknative/utils/DataManager.java
@@ -35,6 +35,7 @@ public class DataManager {
 
             Card card = new Card();
             card.setIndex(i);
+            card.setIsLast(i == data.size()-1);
             card.setViewId(viewId);
             card.setId(validateString(dataRowItem, "id"));
             card.setTitle(validateString(dataRowItem, "title"));

--- a/android/src/main/java/com/rs/leanbacknative/utils/Utils.java
+++ b/android/src/main/java/com/rs/leanbacknative/utils/Utils.java
@@ -1,6 +1,5 @@
 package com.rs.leanbacknative.utils;
 
-import android.util.Log;
 import android.view.View;
 
 import com.facebook.react.bridge.ReadableArray;
@@ -48,8 +47,7 @@ public class Utils {
         }
 
         for (int i = 0; i < forbiddenFocus.size(); i++) {
-            if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_UP)
-            ) {
+            if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_UP)) {
                 cardView.setNextFocusUpId(cardView.getId());
             }
             if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_DOWN)) {

--- a/android/src/main/java/com/rs/leanbacknative/utils/Utils.java
+++ b/android/src/main/java/com/rs/leanbacknative/utils/Utils.java
@@ -1,5 +1,6 @@
 package com.rs.leanbacknative.utils;
 
+import android.util.Log;
 import android.view.View;
 
 import com.facebook.react.bridge.ReadableArray;
@@ -42,12 +43,13 @@ public class Utils {
         if(card.getIndex() != 0){
             forbiddenFocus = filterStringArrayList(forbiddenFocus, Constants.FOCUS_DIRECTION_LEFT);
         }
-        if(!card.getIsLast()){
+        if(!card.isLast()){
             forbiddenFocus = filterStringArrayList(forbiddenFocus, Constants.FOCUS_DIRECTION_RIGHT);
         }
 
         for (int i = 0; i < forbiddenFocus.size(); i++) {
-            if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_UP)) {
+            if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_UP)
+            ) {
                 cardView.setNextFocusUpId(cardView.getId());
             }
             if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_DOWN)) {
@@ -103,8 +105,7 @@ public class Utils {
         List<String> filteredList = new ArrayList<>();
 
         // iterate through the list
-        for (String entry: list)
-        {
+        for (String entry: list) {
             // filter values that match entered value to filter out
             if (!entry.matches(value)) {
                 filteredList.add(entry);

--- a/android/src/main/java/com/rs/leanbacknative/utils/Utils.java
+++ b/android/src/main/java/com/rs/leanbacknative/utils/Utils.java
@@ -5,6 +5,7 @@ import android.view.View;
 import com.facebook.react.bridge.ReadableArray;
 import com.bumptech.glide.request.RequestOptions;
 
+import java.util.List;
 import java.util.Objects;
 
 public class Utils {
@@ -33,18 +34,18 @@ public class Utils {
      * @param forbiddenFocusDirections
      * @param cardView
      */
-    public static void setForbiddenFocusDirections(ReadableArray forbiddenFocusDirections, View cardView) {
+    public static void setForbiddenFocusDirections(List<String> forbiddenFocusDirections, View cardView) {
         for (int i = 0; i < forbiddenFocusDirections.size(); i++) {
-            if (Objects.equals(forbiddenFocusDirections.getString(i), Constants.FOCUS_DIRECTION_UP)) {
+            if (Objects.equals(forbiddenFocusDirections.get(i), Constants.FOCUS_DIRECTION_UP)) {
                 cardView.setNextFocusUpId(cardView.getId());
             }
-            if (Objects.equals(forbiddenFocusDirections.getString(i), Constants.FOCUS_DIRECTION_DOWN)) {
+            if (Objects.equals(forbiddenFocusDirections.get(i), Constants.FOCUS_DIRECTION_DOWN)) {
                 cardView.setNextFocusDownId(cardView.getId());
             }
-            if (Objects.equals(forbiddenFocusDirections.getString(i), Constants.FOCUS_DIRECTION_LEFT)) {
+            if (Objects.equals(forbiddenFocusDirections.get(i), Constants.FOCUS_DIRECTION_LEFT)) {
                 cardView.setNextFocusLeftId(cardView.getId());
             }
-            if (Objects.equals(forbiddenFocusDirections.getString(i), Constants.FOCUS_DIRECTION_RIGHT)) {
+            if (Objects.equals(forbiddenFocusDirections.get(i), Constants.FOCUS_DIRECTION_RIGHT)) {
                 cardView.setNextFocusRightId(cardView.getId());
             }
         }

--- a/android/src/main/java/com/rs/leanbacknative/utils/Utils.java
+++ b/android/src/main/java/com/rs/leanbacknative/utils/Utils.java
@@ -4,7 +4,9 @@ import android.view.View;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.bumptech.glide.request.RequestOptions;
+import com.rs.leanbacknative.models.Card;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -34,18 +36,27 @@ public class Utils {
      * @param forbiddenFocusDirections
      * @param cardView
      */
-    public static void setForbiddenFocusDirections(List<String> forbiddenFocusDirections, View cardView) {
-        for (int i = 0; i < forbiddenFocusDirections.size(); i++) {
-            if (Objects.equals(forbiddenFocusDirections.get(i), Constants.FOCUS_DIRECTION_UP)) {
+    public static void setForbiddenFocusDirections(ReadableArray forbiddenFocusDirections, Card card, View cardView) {
+        // Find the right array of blocked directions for the card
+        List<String> forbiddenFocus = toStringArrayList(forbiddenFocusDirections);
+        if(card.getIndex() != 0){
+            forbiddenFocus = filterStringArrayList(forbiddenFocus, Constants.FOCUS_DIRECTION_LEFT);
+        }
+        if(!card.getIsLast()){
+            forbiddenFocus = filterStringArrayList(forbiddenFocus, Constants.FOCUS_DIRECTION_RIGHT);
+        }
+
+        for (int i = 0; i < forbiddenFocus.size(); i++) {
+            if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_UP)) {
                 cardView.setNextFocusUpId(cardView.getId());
             }
-            if (Objects.equals(forbiddenFocusDirections.get(i), Constants.FOCUS_DIRECTION_DOWN)) {
+            if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_DOWN)) {
                 cardView.setNextFocusDownId(cardView.getId());
             }
-            if (Objects.equals(forbiddenFocusDirections.get(i), Constants.FOCUS_DIRECTION_LEFT)) {
+            if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_LEFT)) {
                 cardView.setNextFocusLeftId(cardView.getId());
             }
-            if (Objects.equals(forbiddenFocusDirections.get(i), Constants.FOCUS_DIRECTION_RIGHT)) {
+            if (Objects.equals(forbiddenFocus.get(i), Constants.FOCUS_DIRECTION_RIGHT)) {
                 cardView.setNextFocusRightId(cardView.getId());
             }
         }
@@ -65,5 +76,40 @@ public class Utils {
             default:
                 return RequestOptions.fitCenterTransform();
         }
+    }
+
+    /**
+     * Takes a readable array and converts it to ArrayList<String>
+     * @param array
+     * @return ArrayList<String>
+     */
+    public static ArrayList<String> toStringArrayList(ReadableArray array) {
+        ArrayList<String> arrayList = new ArrayList<>();
+
+        for (int i = 0; i < array.size(); i++) {
+            arrayList.add(array.getString(i));
+        }
+        return arrayList;
+    }
+
+    /**
+     * Takes a List containing string values and removes all values that match given
+     * @param list - a list that needs to be filtered
+     * @param value - string value which needs to be filtered out
+     * @return List<String>
+     */
+    public static List<String> filterStringArrayList(List<String> list, String value){
+        // create an empty list
+        List<String> filteredList = new ArrayList<>();
+
+        // iterate through the list
+        for (String entry: list)
+        {
+            // filter values that match entered value to filter out
+            if (!entry.matches(value)) {
+                filteredList.add(entry);
+            }
+        }
+        return filteredList;
     }
 }

--- a/example/src/screens/LeanbackRows.js
+++ b/example/src/screens/LeanbackRows.js
@@ -30,6 +30,7 @@ const LeanbackRows = () => {
                         height: 173,
                     }}
                     onFocus={(item) => console.log(item)}
+                    forbiddenFocusDirections={['left', 'right']}
                 />
             </View>
             <View setSnapPoint>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reactseals/react-native-leanback",
   "title": "React Native Leanback",
-  "version": "2.0.4-beta.0",
+  "version": "2.0.4-beta.1",
   "description": "Leanback implementation for React Native Android TV",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description

Setting `forbiddenFocusDirections` left and right meant focus to those directions is blocked for each of the packshots, which is not desired behaviour as rendering a row you would want to handle focus from its edge items. This PR attempts to fix just that. 
Now given forbidden directions are filtered and all items that are not the first item cannot have blocked focus direction left, similarly only the last item can have blocked focus direction to the right.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My change does not require a change to the documentation.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
